### PR TITLE
Fix error if API returns return code 1 as int

### DIFF
--- a/licensing/methods.py
+++ b/licensing/methods.py
@@ -81,7 +81,7 @@ class Key:
         
         jobj = json.loads(response)
 
-        if jobj == None or jobj["result"] == "1":
+        if jobj == None or str(jobj["result"]) == "1":
             if jobj != None:
                 return (None, jobj["message"])
             else:


### PR DESCRIPTION
The REST-API returns the return code 1 as a string in most situations, but as an integer in others. The Python-API cannot handle it if an integer is returned.

Steps to reproduce:
1. Create a trial key for machine using the Python-API
2. Activate trial key for machine using the Python-API
3. Block trial key on the web interface
4. Create a new trial key using the Python-API

This is a fix for this behavior.


A note on the side - I would consider this inconsistent behavior of the API a bug, which should be fixed in the REST-API ultimatively.